### PR TITLE
Add miraculix testing library

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -107,6 +107,15 @@
   , repo = "https://github.com/spacchetti/purescript-metadata.git"
   , version = "v0.14.3"
   }
+, miraculix =
+  { dependencies =
+    [ "prelude"
+    , "foldable-traversable"
+    , "newtype"
+    ]
+  , repo = "https://github.com/thought2/purescript-miraculix.git"
+  , version = "v0.1.0"
+  }
 , newtype =
   { dependencies = [ "prelude", "safe-coerce" ]
   , repo = "https://github.com/purenix-org/purescript-newtype.git"


### PR DESCRIPTION
Hi, first of all thanks for writing purenix! I think this is a really useful and promising approach to write typed nix!
It inspired me to write this small testing library which is inspired by `tasty`. With this PR I'd like to ask if it could be listed in the package set.

Working with the current purenix version was really smooth.
The only issue I encountered was the quoting thing already mentioned in [here](https://github.com/purenix-org/purenix/issues/35).

