### PR TITLE
Add CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: "CI"
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Tests
+        run: nix develop --command make tests
+
+  deploy:
+    needs: checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Generate docs
+        run: nix develop --command make docs
+
+      - name: Deploy Docs to GH Pages
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages
+          folder: generated-docs/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.spago
+/output
+.psc-ide-port
+/generated-docs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+tests:
+	spago verify-set
+
+docs:
+	spago docs --deps-only

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # temp-package-set
+
 Temporary package set for purenix
+
+# Docs
+
+- [API documentation](https://purenix-org.github.io/temp-package-set) for all Packages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # temp-package-set
 
-Temporary package set for purenix
+This repo contains a temporary package set for purenix in [`./packages.dhall`](./packages.dhall).
+
+See the [PureNix QuickStart Guide](https://github.com/purenix-org/purenix/blob/main/docs/quick-start.md) for how to get started using this temporary package set.
+
+See [this issue](https://github.com/purenix-org/purenix/issues/36) for why this is only a _temporary_ package set.
 
 # Docs
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1636886446,
+        "narHash": "sha256-4xsVM2H8CG3d/3V+GqDDLDOmb3kdrugbqKVyrg8Q/zc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5cb226a06c49f7a2d02863d0b5786a310599df6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "purenix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1642920914,
+        "narHash": "sha256-WMVRQJR1b0yDp5gkE5aSJDFJey9tLfJIC65G7P7RDso=",
+        "owner": "purenix-org",
+        "repo": "purenix",
+        "rev": "11bfb8b00997c61511d06d18000199aa34a41bda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purenix-org",
+        "repo": "purenix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "purenix",
+          "nixpkgs"
+        ],
+        "purenix": "purenix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "temp-package-set";
+
+  inputs.purenix.url = "github:purenix-org/purenix";
+  inputs.nixpkgs.follows = "purenix/nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils, purenix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlay = self: _: { };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            overlay
+          ];
+        };
+      in
+      {
+        devShell = purenix.devShells.${system}.use-purenix;
+      }
+    );
+}
+

--- a/packages.dhall
+++ b/packages.dhall
@@ -108,11 +108,7 @@
   , version = "v0.14.3"
   }
 , miraculix =
-  { dependencies =
-    [ "prelude"
-    , "foldable-traversable"
-    , "newtype"
-    ]
+  { dependencies = [ "prelude", "foldable-traversable", "newtype" ]
   , repo = "https://github.com/thought2/purescript-miraculix.git"
   , version = "v0.1.0"
   }

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,27 @@
+let List/map = https://prelude.dhall-lang.org/v11.1.0/List/map
+
+let Map = https://prelude.dhall-lang.org/v15.0.0/Map/Type
+
+let getKeys
+    : ∀(a : Type) → Map Text a → List Text
+    = λ(a : Type) →
+      λ(xs : Map Text a) →
+        List/map
+          { mapKey : Text, mapValue : a }
+          Text
+          (λ(x : { mapKey : Text, mapValue : a }) → x.mapKey)
+          xs
+
+let packages = ./packages.dhall
+
+let dependencies =
+      getKeys
+        { dependencies : List Text, repo : Text, version : Text }
+        (toMap packages)
+
+in  { name = "pkgs-with-all-deps"
+    , dependencies
+    , backend = "purenix"
+    , packages
+    , sources = [ "src/**/*.purs" ]
+    }

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,3 +1,7 @@
+-- This is a dummy spago.dhall file used for CI.  This takes all the packages defined in
+-- ./packages.dhall and adds them as dependencies.
+-- See ./.github/workflows/ci.yml for how this file is used.
+
 let List/map = https://prelude.dhall-lang.org/v11.1.0/List/map
 
 let Map = https://prelude.dhall-lang.org/v15.0.0/Map/Type


### PR DESCRIPTION
This PR adds a simple CI/CD pipeline to this repo

- CI checks if `spago verify-set` succeeds
- CD uses a dummy `spago.dhall` file to generate docs for all packages in the set. It will be deployed to GH pages. With this we'd effectively have a pursuit-like global documentation for the current set.